### PR TITLE
Change token

### DIFF
--- a/.github/workflows/node_ci.yml
+++ b/.github/workflows/node_ci.yml
@@ -33,4 +33,4 @@ jobs:
       uses: romeovs/lcov-reporter-action@v0.2.21
       with:
         title: Code Coverage
-        github-token: ${{ secrets.COVERAGE_TOKEN }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add Github actions default token to coverage CI, to comment as a bot, not me.